### PR TITLE
Ensure that non-real spell cc are always available

### DIFF
--- a/Config.lua
+++ b/Config.lua
@@ -91,7 +91,11 @@ local CC_LIST = {
     "CYCLONE", "TURNUNDEAD", "SCAREBEAST", "SEDUCE", "TURNEVIL", "BLIND", "BURN",
     "HEX", "REPENTANCE", "BINDELEMENTAL"
 }
-local AVAILABLE_CC = {}
+local AVAILABLE_CC = {
+	[1] = true, -- 00NONE
+	[7] = true, -- KITE
+	[19] = true, -- BURN
+}
 do
     local ccids = LibStub("MagicComm-1.0").spellIdToCCID
     for spellid in pairs(ccids) do


### PR DESCRIPTION
I noticed that the CC for `None`, `Kite` and `Burn` were not available, and it appears to be due to the filtering that was added in [this commit](https://github.com/neotron/WoW-MagicMarker/commit/584d0b47f7ee16beca4eba2c74d0b9c02d31de1d)

This change simply marks `None`, `Kite` and `Burn` as always available so that it can be picked when configuring mobs.